### PR TITLE
Fix broken imports.

### DIFF
--- a/wagtail_comments_xtd/views.py
+++ b/wagtail_comments_xtd/views.py
@@ -1,5 +1,5 @@
 from django.contrib import messages
-from wagtail.wagtailcore.models import Page
+from wagtail.core.models import Page
 from django.shortcuts import redirect, render
 from django_comments_xtd.models import XtdComment
 from django.utils.translation import ugettext as _

--- a/wagtail_comments_xtd/wagtail_hooks.py
+++ b/wagtail_comments_xtd/wagtail_hooks.py
@@ -1,8 +1,8 @@
-from django.core import urlresolvers
+from django.urls import reverse
 from wagtail_comments_xtd import urls
-from wagtail.wagtailcore import hooks
+from wagtail.core import hooks
 from django.conf.urls import include, url
-from wagtail.wagtailadmin.menu import MenuItem
+from wagtail.admin.menu import MenuItem
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -17,7 +17,7 @@ def register_admin_urls():
 def register_styleguide_menu_item():
     return MenuItem(
         _('Comments'),
-        urlresolvers.reverse('wagtail_comments_xtd_pages'),
+        reverse('wagtail_comments_xtd_pages'),
         classnames='icon icon-fa-comments-o',
         order=1000
     )


### PR DESCRIPTION
Django 2.0 moved:

 - `django.core.urlresolvers.reverse` to `django.urls.reverse`

Wagtail 2.0 moved:

 - `wagtail.wagtailcore.models` to `wagtail.core.models`
 - `wagtail.wagtailadmin.menu` to `wagtail.admin.menu`